### PR TITLE
Get Klaus Dormann's test suite passing

### DIFF
--- a/lib/mos6510/cpu.rb
+++ b/lib/mos6510/cpu.rb
@@ -31,6 +31,20 @@ module Mos6510
       @cpu.pc = new_pc
     end
 
+    def inspect
+      status = @cpu.p
+      status_encoded = [
+        (status & Mos6510::Flag::N) != 0, (status & Mos6510::Flag::V) != 0, (status & Mos6510::Flag::B2) != 0, (status & Mos6510::Flag::B1) != 0, (status & Mos6510::Flag::D) != 0,
+        (status & Mos6510::Flag::I) != 0, (status & Mos6510::Flag::Z) != 0, (status & Mos6510::Flag::C) != 0
+      ].reduce(0) { |acc, flag| (acc << 1) + (flag ? 1 : 0) }
+
+      format(
+        'a: 0x%02x, x: 0x%02x, y: 0x%02x, sp: 0x%02x, ' \
+        'pc: 0x%04x, op: 0x%02x, status: 0b%08b, memory: %i',
+        @cpu.a, @cpu.x, @cpu.y, @cpu.s, @cpu.pc, @cpu.getmem(@cpu.pc), status_encoded, @memory.sum
+      )
+    end
+
     def peek(address)
       @cpu.getmem(address)
     end

--- a/spec/cpu_spec.rb
+++ b/spec/cpu_spec.rb
@@ -16,7 +16,7 @@ module Mos6510
       expect(cpu.peek(4000)).to eq(7)
     end
 
-    it "can run the whole Klaus Dormann functional test suite", skip: "Needs more work!" do
+    it "can run the whole Klaus Dormann functional test suite" do#, skip: "Needs more work!" do
       # TODO: This suite does _not_ pass currently. It relies on you copying
       # bin_files/6502_functional_test.bin from https://github.com/Klaus2m5/6502_65C02_functional_tests
       # (and even then, it ends up on the wrong PC)
@@ -29,9 +29,9 @@ module Mos6510
       last_pc = 0
       while last_pc != cpu.pc
         last_pc = cpu.pc
-        #puts cpu.inspect
+        puts cpu.inspect
 
-        puts "Stepping: #{last_pc}"
+        #puts "Stepping: #{last_pc}"
         cpu.step
       end
 


### PR DESCRIPTION
Trying to get these functional tests passing: https://github.com/Klaus2m5/6502_65C02_functional_tests

Currently, you have to manually copy `bin_files/6502_functional_test.bin` from that repo to the `spec` folder in this repo.

Running `rake spec` then produces a _lot_ of output. Currently I am comparing this to the output of running the specs from https://github.com/hainesr/mos6502, where `Mos6502::Cpu#inspect` has been modified to

```ruby
    def inspect
      format(
        'a: 0x%02x, x: 0x%02x, y: 0x%02x, sp: 0x%02x, ' \
        'pc: 0x%04x, op: 0x%02x, status: 0b%08b, memory: %i',
        @a, @x, @y, @sp, @pc, @memory.get(@pc), @status.encode, @memory.sum
      )
    end
```

...to reflect changes to the memory.

However, I think getting these functional tests passing requires us to implement BCD logic. I'm not sure I'm up for that. But let's see how far we can get.

This is a very nice (though somewhat brief) overview of all the MOS 6502 instructions: https://www.masswerk.at/6502/6502_instruction_set.html#SBC